### PR TITLE
Fix Dockerhub builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,20 @@ RUN apk update && \
 
 FROM builder as bibspace-base
 
-RUN mkdir BibSpace
-COPY lib/ /BibSpace/lib
+RUN mkdir -p BibSpace
 COPY bin/ /BibSpace/bin
+COPY fixture/ /BibSpace/fixture
+COPY lib/ /BibSpace/lib
+COPY util/ /BibSpace/util
 COPY t/ /BibSpace/t
 
 # Migration 0.5.0 -> 0.5.0-docker
-RUN mkdir -p json_data \
-  ; cp bibspace_preferences.json json_data/bibspace_preferences.json \
-  ; cp bibspace_stats.json json_data/bibspace_stats.json \
-  ; exit 0
+RUN mkdir -p /BibSpace/json_data \
+  ; [ -f bibspace_preferences.json ] \
+  && cp bibspace_preferences.json /BibSpace/json_data/bibspace_preferences.json \
+  ; [ -f bibspace_stats.json ] \
+  && cp bibspace_stats.json /BibSpace/json_data/bibspace_stats.json \
+   ; exit 0
 
 ENV EV_EXTRA_DEFS -DEV_NO_ATFORK
 ENV TZ=Europe/Berlin
@@ -42,7 +46,7 @@ RUN apk update \
 RUN echo "Europe/Berlin" > /config/etc/timezone
 LABEL version="0.6.0"
 EXPOSE 8083
-HEALTHCHECK --interval=5s --timeout=3s CMD curl --fail http://localhost:8083/system_status || exit 1
+HEALTHCHECK --interval=30s --timeout=15s CMD curl --fail http://localhost:8083/system_status || exit 1
 
 FROM bibspace-base as bibspace
 # For production

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,16 +1,13 @@
+---
 version: '3'
 services:
 
   sut:
-    image: bibspace
-    command: sh -c "cd /BibSpace && prove -lr /BibSpace/t"
+    build: .
+    command: sh -c 'cd /BibSpace && util/wait-for db:3306 -- prove -lr /BibSpace/t'
     restart: "no"
-    volumes:
-      - ${PWD}/public/uploads:/BibSpace/public/uploads
-      - ${PWD}/backups:/BibSpace/backups
-      - ${PWD}/log:/BibSpace/log
-      - ${PWD}/json_data:/BibSpace/json_data
-      - ${PWD}/fixture:/BibSpace/fixture
+    depends_on:
+      - db
     environment:
       BIBSPACE_RUN_MODE: production
       BIBSPACE_DB_HOST: db:3306
@@ -19,3 +16,16 @@ services:
       BIBSPACE_DB_DATABASE: bibspace
       BIBSPACE_CONFIG: lib/BibSpace/files/config/default.conf
       BIBSPACE_USE_DUMP: 0
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: passw00rdROOT
+      MYSQL_DATABASE: bibspace
+      MYSQL_USER: bibspace_user
+      MYSQL_PASSWORD: passw00rd
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-u", "root", "-ppassw00rdROOT"]
+      timeout: 5s
+      retries: 6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,10 @@
 ---
 version: '3'
 
-# the db container is not accessing from outside of docker,
-# so the password is not an issue
-
 services:
   db:
     image: mysql:5.7
     volumes:
-      #  path/on/host:path/in/container
       - ./db_data:/var/lib/mysql
     restart: always
     environment:

--- a/util/wait-for
+++ b/util/wait-for
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"
+


### PR DESCRIPTION
This PR modifies the Docker-related files, so that builds on Dockerhub are fixed.

In particular:
- Add missing files and directories to the image in Dockerfile
- Increase `HEALTHCHECK` intervals and timeouts to give more time for the DB to start
- Apply `wait-for` script to wait with tests until DB is fully started